### PR TITLE
Automatically launch and control telegram-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ to receive messages, and connects to tg telnet interface to send them.
 - [x] Sending/receiving group messages
 - [ ] Sending multiline messages (not supported on tg telnet interface)
 - [ ] Sending/receiving secret chat messages
-- [ ] Sending images and media
+- [x] Sending images
+- [ ] Sending media
 
 ## Setup
 
@@ -102,29 +103,14 @@ $ npm install zenitram/hubot-tg --save
 
 ### Run Hubot
 
-In one terminal, start telegram-cli on a specific port:
-
-```
-$ cd /path/to/hubot
-$ cd node_modules/hubot-tg
-$ /path/to/tg/bin/telegram-cli -s hubot.lua -P 1123
-```
-
-In another terminal, start Hubot. If you aren't using port 1123,
-you'll need to specify it with `HUBOT_TG_PORT`.
+In terminal, start hubot:
 
 ```
 $ cd /path/to/hubot
 $ bin/hubot -a tg
 ```
 
-## Config parameters
-
-### Hubot
-You can set ```HUBOT_TG_HOST``` and ```HUBOT_TG_PORT``` env variables to set how Hubot should connect to tg.
-
-### tg
-You can set the env variable ```TG_HUBOT_URL``` to where to find Hubot.
+The telegram-cli start as a child process, you don't have to worry.
 
 ## Acknowledgements
 - @yagop for [telegram-bot](https://github.com/yagop/telegram-bot), which inspired this

--- a/hubot.lua
+++ b/hubot.lua
@@ -1,6 +1,8 @@
+package.path = package.path .. ";../?.lua"
+
 http = require("socket.http")
 ltn12 = require("ltn12")
-JSON = (loadfile 'JSON.lua')()
+JSON = require('JSON')
 started = 0
 our_id = 0
 hubot_endpoint = os.getenv("TG_HUBOT_URL")
@@ -68,7 +70,7 @@ function on_msg_receive (msg)
   end
   body = JSON:encode(msg)
   if(msg.from.id ~= our_id) then
-    http.request{
+    http.request {
       url = hubot_endpoint .. 'hubot_tg/msg_receive',
       method = 'POST',
       headers = { ["Content-Type"] = "application/json", ["Content-Length"] = body:len()},
@@ -77,6 +79,7 @@ function on_msg_receive (msg)
   end
 
   mark_read(get_receiver(msg), ok_cb, false)
+
 end
 
 function on_our_id (id)

--- a/src/tg.coffee
+++ b/src/tg.coffee
@@ -1,28 +1,105 @@
-{Robot, Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage} = require 'hubot'
-net           = require 'net'
+{ Robot, Adapter, TextMessage, EnterMessage, LeaveMessage, TopicMessage } = require 'hubot'
+net   = require 'net'
+fs    = require 'fs'
+url   = require 'url'
+http  = require 'http'
+prog  = require 'child_process'
+path  = require 'path'
 
 class Tg extends Adapter
-  constructor: (robot) ->
-    @robot = robot
-    @port = process.env['HUBOT_TG_PORT'] || 1123
-    @host = process.env['HUBOT_TG_HOST'] || 'localhost'
 
+  constructor: (robot) ->  
+    @robot = robot
+    @socket = "/tmp/#{Date.now()}.sock"
+    @imageExtensions = [".jpg", ".jpeg", ".png", ".gif"]
+    @tempdir = process.env['HUBOT_TG_TMPDIR'] || '/tmp/tg'
+
+    # creating @tempdir or use /tmp
+    mkdir = "mkdir -p #{@tempdir}"
+    child = prog.exec mkdir, (err, stdout, stderr) ->
+      @tempdir = "/tmp" if err
+
+    # start telegram-cli
+    @bindCli()
+
+  bindCli: ->
+  
+    args = [
+      '-k', '/etc/tg-server.pub',
+      '-s', "#{__dirname}/../hubot.lua",
+      '-S', @socket,
+      '-W',
+      '-R',
+      '-C'
+    ]
+  
+    cli = prog.spawn 'telegram-cli', args, { detached: true }
+    cli.unref()
+    
+    cli.stdout.on 'data', (data) ->
+      console.log data.toString().replace(/\r?\n/g, '')
+      
+    cli.stderr.on 'data', (data) ->
+      console.log data.toString().replace(/\r?\n/g, '')
+      
+    cli.on 'close', (code) ->
+      console.log "*** Cli exit with code: #{code}"
+      process.exit(1) # relaunch all the things
+
+    process.on 'exit', (options, err) ->
+      cli.kill()
+    
   send: (envelope, strings...) ->
+    if strings.length < 2 and (@imageExtensions.some (word) -> ~strings.toString().indexOf word)
+      _strings = strings.toString()
+      @get_image(envelope, _strings, @socket, @send_photo)
+      return
+
     # Flatten out strings to send, as the tg telnet interface does not allow sending newlines
     flattened = []
     for str in strings
-      if typeof str != 'undefined'
+      if str?
         for line in str.toString().split(/\r?\n/)
           if Array.isArray line
             flattened = flattened.concat line
           else
             flattened.push line
 
-    client = net.connect @port, @host, ->
-      messages = flattened.map (str) -> "msg "+envelope.room+" \""+str.replace(/"/g, '\\"')+"\"\n"
-      client.write messages.join("\n"), ->
-        client.end()
+      client = net.connect { path: @socket }, ->
+        messages = flattened.map (str) -> "msg #{envelope.room} \"#{str.replace(/"/g, '\\"')}\"\n"
+        client.write messages.join("\n"), ->
+          client.end()
 
+  get_image: (envelope, image_url, socket, callback) ->
+
+    DOWNLOAD_DIR = @tempdir
+
+    options =
+      host: url.parse(image_url).host
+      path: url.parse(image_url).pathname
+
+    filename = Date.now() + path.extname(options.path)
+    fileFullPath = "#{DOWNLOAD_DIR}/#{filename}"
+    http.get options, (res) ->
+      image_data = ''
+      res.setEncoding 'binary'
+      res.on 'data', (chunk) ->
+        image_data += chunk
+      .on 'end', ->
+        fs.writeFile fileFullPath, image_data, 'binary', (err) ->
+          if err
+            console.log "*** Error saving image"
+          else
+            callback(envelope, socket, fileFullPath)
+
+  send_photo: (envelope, socket, fileLocation) ->
+    message = "send_photo #{envelope.room} #{fileLocation}\n"
+    client = net.connect { path: socket }, ->
+      client.write message, ->
+        setTimeout ->
+          fs.unlink fileLocation      
+          client.end()
+        , 3000
 
   emote: (envelope, strings...) ->
     @send envelope, "* #{str}" for str in strings
@@ -36,16 +113,14 @@ class Tg extends Adapter
 
   run: ->
     self = @
-    # We will listen here to incoming events from tg - inspired on hubot-slack v2
     self.robot.router.post "/hubot_tg/msg_receive", (req, res) ->
-      msg = req.body
+      msg  = req.body
       room = if msg.to.type == 'user' then self.entityToID(msg.from) else self.entityToID(msg.to)
       from = self.entityToID(msg.from)
       user = self.robot.brain.userForId from, name: msg.from.print_name, room: room
-      self.receive new TextMessage user, msg.text, msg.id
+      self.receive new TextMessage user, msg.text, msg.id if msg.text
       res.end ""
     self.emit 'connected'
-
 
 exports.use = (robot) ->
   new Tg robot


### PR DESCRIPTION
It's not needed to launch a separate command line or process for telegram-cli, the adapter launch it.
With this method I'm able to use a single dyno on heroku :see_no_evil: 

Another addition is that I use a unix socket to write messages, so no port is needed.
